### PR TITLE
Use zaraza as a general dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache Maven local repository
         uses: actions/cache@v2.1.3

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache Maven local repository
         uses: actions/cache@v2.1.3

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache Maven local repository
         uses: actions/cache@v2.1.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Cache Maven local repository
         uses: actions/cache@v2.1.3

--- a/custom-stuff-api/pom.xml
+++ b/custom-stuff-api/pom.xml
@@ -60,20 +60,12 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ru.divinecraft</groupId>
+            <artifactId>zaraza-common-api</artifactId>
+        </dependency>
 
         <!-- Libraries -->
-        <dependency>
-            <groupId>ru.progrm-jarvis</groupId>
-            <artifactId>java-commons</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ru.progrm-jarvis.minecraft</groupId>
-            <artifactId>minecraft-commons</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ru.progrm-jarvis.minecraft</groupId>
-            <artifactId>fake-entity-lib</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.flowpowered</groupId>
             <artifactId>flow-nbt</artifactId>

--- a/custom-stuff-api/src/main/java/ru/divinecraft/customstuff/api/block/CustomBlock.java
+++ b/custom-stuff-api/src/main/java/ru/divinecraft/customstuff/api/block/CustomBlock.java
@@ -10,7 +10,7 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import ru.divinecraft.customstuff.api.block.properties.BlockProperties;
-import ru.progrm_jarvis.javacommons.annotation.ownership.Own;
+import ru.progrm_jarvis.javacommons.ownership.annotation.Own;
 
 public interface CustomBlock {
 

--- a/custom-stuff-api/src/main/java/ru/divinecraft/customstuff/api/chunk/ArrayBasedChunkDataStorage.java
+++ b/custom-stuff-api/src/main/java/ru/divinecraft/customstuff/api/chunk/ArrayBasedChunkDataStorage.java
@@ -6,8 +6,7 @@ import org.bukkit.util.Vector;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import ru.progrm_jarvis.javacommons.pair.Pair;
-import ru.progrm_jarvis.javacommons.pair.SimplePair;
+import ru.progrm_jarvis.javacommons.object.Pair;
 
 import java.util.*;
 
@@ -223,7 +222,7 @@ public class ArrayBasedChunkDataStorage<@NotNull T> implements ChunkDataStorage<
                 T value;
                 if ((value = layer[xz]) != null) {
                     // next was found
-                    next = SimplePair.of(new Vector(xFromIndexXZ(xz), y, zFromIndexXZ(xz)), value);
+                    next = Pair.of(new Vector(xFromIndexXZ(xz), y, zFromIndexXZ(xz)), value);
 
                     // check if this layer has ended
                     if ((this.leftOnCurrentLayer = --leftOnCurrentLayer) == 0) this.layer = null;

--- a/custom-stuff-api/src/main/java/ru/divinecraft/customstuff/api/chunk/ChunkDataStorage.java
+++ b/custom-stuff-api/src/main/java/ru/divinecraft/customstuff/api/chunk/ChunkDataStorage.java
@@ -4,7 +4,7 @@ import org.bukkit.util.Vector;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import ru.progrm_jarvis.javacommons.pair.Pair;
+import ru.progrm_jarvis.javacommons.object.Pair;
 
 import javax.annotation.Nonnegative;
 

--- a/custom-stuff-api/src/main/java/ru/divinecraft/customstuff/api/service/BukkitLoadingCustomStuff.java
+++ b/custom-stuff-api/src/main/java/ru/divinecraft/customstuff/api/service/BukkitLoadingCustomStuff.java
@@ -1,6 +1,8 @@
 package ru.divinecraft.customstuff.api.service;
 
 import org.bukkit.plugin.Plugin;
+import ru.divinecraft.zaraza.common.api.annotation.BukkitService;
 
 @FunctionalInterface
+@BukkitService("CustomStuff")
 public interface BukkitLoadingCustomStuff extends LoadingCustomStuff<Plugin> {}

--- a/custom-stuff-api/src/main/java/ru/divinecraft/customstuff/api/service/CustomStuff.java
+++ b/custom-stuff-api/src/main/java/ru/divinecraft/customstuff/api/service/CustomStuff.java
@@ -7,7 +7,9 @@ import ru.divinecraft.customstuff.api.inventory.manager.CustomInventoryManager;
 import ru.divinecraft.customstuff.api.item.manager.CustomItemManager;
 import ru.divinecraft.customstuff.api.recipe.manager.RecipeManager;
 import ru.divinecraft.customstuff.api.render.CustomBlockRenderer;
+import ru.divinecraft.zaraza.common.api.annotation.BukkitService;
 
+@BukkitService("CustomStuff")
 public interface CustomStuff {
 
     @Contract(pure = true)

--- a/custom-stuff-api/src/main/java/ru/divinecraft/customstuff/api/util/NamespacedKeys.java
+++ b/custom-stuff-api/src/main/java/ru/divinecraft/customstuff/api/util/NamespacedKeys.java
@@ -2,7 +2,6 @@ package ru.divinecraft.customstuff.api.util;
 
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
-import lombok.var;
 import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;

--- a/custom-stuff-api/src/main/java/ru/divinecraft/customstuff/api/util/NbtUtil.java
+++ b/custom-stuff-api/src/main/java/ru/divinecraft/customstuff/api/util/NbtUtil.java
@@ -223,7 +223,7 @@ public class NbtUtil {
     }
 
     public long readLong(final @NotNull CompoundMap tags, final @NotNull String tagName,
-                       final long defaultValue) {
+                         final long defaultValue) {
         final Tag<?> tag;
         if ((tag = tags.get(tagName)) == null) return defaultValue;
 
@@ -237,7 +237,7 @@ public class NbtUtil {
     }
 
     public long readLong(final @NotNull CompoundMap tags, final @NotNull String tagName,
-                        final LongSupplier defaultValueSupplier) {
+                         final LongSupplier defaultValueSupplier) {
         final Tag<?> tag;
         if ((tag = tags.get(tagName)) == null) return defaultValueSupplier.getAsLong();
 

--- a/custom-stuff-api/src/test/java/ru/divinecraft/customstuff/api/chunk/ArrayBasedChunkDataStorageTest.java
+++ b/custom-stuff-api/src/test/java/ru/divinecraft/customstuff/api/chunk/ArrayBasedChunkDataStorageTest.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import ru.progrm_jarvis.javacommons.pair.SimplePair;
+import ru.progrm_jarvis.javacommons.object.Pair;
 
 import java.util.NoSuchElementException;
 import java.util.stream.StreamSupport;
@@ -22,7 +22,7 @@ class ArrayBasedChunkDataStorageTest {
     @BeforeEach
     void setUp() {
         chunkDataStorage = ArrayBasedChunkDataStorage.withAllocator(
-                new ArrayBasedChunkDataStorage.LayerAllocator<String>() {
+                new ArrayBasedChunkDataStorage.LayerAllocator<>() {
                     @Override
                     public @Nullable String @NotNull [] @Nullable [] allocateLayers() {
                         return new String[LAYERS_COUNT][];
@@ -216,7 +216,7 @@ class ArrayBasedChunkDataStorageTest {
         chunkDataStorage.set((byte) 1, (byte) 7, (byte) 2, "cyanide");
 
         assertThat(StreamSupport.stream(chunkDataStorage.spliterator(), false)).containsExactly(
-                SimplePair.of(new Vector(1, 7, 2), "cyanide")
+                Pair.of(new Vector(1, 7, 2), "cyanide")
         );
     }
 
@@ -227,9 +227,9 @@ class ArrayBasedChunkDataStorageTest {
         chunkDataStorage.set((byte) 1, (byte) 8, (byte) 10, "happiness");
 
         assertThat(StreamSupport.stream(chunkDataStorage.spliterator(), false)).containsExactly(
-                SimplePair.of(new Vector(1, 7, 2), "cyanide"),
-                SimplePair.of(new Vector(1, 8, 0), "and"),
-                SimplePair.of(new Vector(1, 8, 10), "happiness")
+                Pair.of(new Vector(1, 7, 2), "cyanide"),
+                Pair.of(new Vector(1, 8, 0), "and"),
+                Pair.of(new Vector(1, 8, 10), "happiness")
         );
     }
 
@@ -248,17 +248,17 @@ class ArrayBasedChunkDataStorageTest {
         chunkDataStorage.set((byte) 15, (byte) 255, (byte) 15, "close to border #6");
 
         assertThat(StreamSupport.stream(chunkDataStorage.spliterator(), false)).containsExactly(
-                SimplePair.of(new Vector(0, 0, 0), "zero"),
-                SimplePair.of(new Vector(0, 0, 1), "practically zero"),
-                SimplePair.of(new Vector(1, 7, 2), "cyanide"),
-                SimplePair.of(new Vector(1, 8, 0), "and"),
-                SimplePair.of(new Vector(1, 8, 10), "happiness"),
-                SimplePair.of(new Vector(1, 254, 10), "close to border #1"),
-                SimplePair.of(new Vector(1, 255, 10), "close to border #2"),
-                SimplePair.of(new Vector(14, 255, 14), "close to border #3"),
-                SimplePair.of(new Vector(14, 255, 15), "close to border #4"),
-                SimplePair.of(new Vector(15, 255, 14), "close to border #5"),
-                SimplePair.of(new Vector(15, 255, 15), "close to border #6")
+                Pair.of(new Vector(0, 0, 0), "zero"),
+                Pair.of(new Vector(0, 0, 1), "practically zero"),
+                Pair.of(new Vector(1, 7, 2), "cyanide"),
+                Pair.of(new Vector(1, 8, 0), "and"),
+                Pair.of(new Vector(1, 8, 10), "happiness"),
+                Pair.of(new Vector(1, 254, 10), "close to border #1"),
+                Pair.of(new Vector(1, 255, 10), "close to border #2"),
+                Pair.of(new Vector(14, 255, 14), "close to border #3"),
+                Pair.of(new Vector(14, 255, 15), "close to border #4"),
+                Pair.of(new Vector(15, 255, 14), "close to border #5"),
+                Pair.of(new Vector(15, 255, 15), "close to border #6")
         );
     }
 }

--- a/custom-stuff-api/src/test/java/ru/divinecraft/customstuff/api/util/NamespacedKeysTest.java
+++ b/custom-stuff-api/src/test/java/ru/divinecraft/customstuff/api/util/NamespacedKeysTest.java
@@ -1,7 +1,6 @@
 package ru.divinecraft.customstuff.api.util;
 
 import lombok.val;
-import lombok.var;
 import org.bukkit.NamespacedKey;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -16,6 +15,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class NamespacedKeysTest {
 
+    @SuppressWarnings("deprecation") // creation of NamespacedKey
     static @NotNull Stream<@NotNull Arguments> validNamespaceComponents() {
         return Stream.of(
                 arguments("hello", "world", new NamespacedKey("hello", "world"))
@@ -23,12 +23,7 @@ class NamespacedKeysTest {
     }
 
     static @NotNull Stream<@NotNull Arguments> invalidNamespaceComponents() {
-        final String hugeString;
-        {
-            val hugeStringBuilder = new StringBuilder();
-            for (var i = 0; i < 255; i++) hugeStringBuilder.append('a');
-            hugeString = hugeStringBuilder.toString();
-        }
+        val hugeString = "a".repeat(255);
 
         return Stream.of(
                 arguments("ohyeah", "just great"),

--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <!-- Dependency versions -->
-        <version.minecraft-utils>0.1.0-SNAPSHOT</version.minecraft-utils>
+        <version.zaraza>1.0.0-SNAPSHOT</version.zaraza>
         <version.junit>5.8.0-M1</version.junit>
     </properties>
 
@@ -79,8 +79,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
                     <configuration>
-                        <source>${java.version}</source>
-                        <target>${java.version}</target>
+                        <release>${java.version}</release>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -143,17 +142,17 @@
     <repositories>
         <!-- spigot-api -->
         <repository>
-            <id>spigot-repo</id>
+            <id>spigotmc</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
-        <!-- minecraft-utils snapshots -->
+        <!-- padla snapshots, minecraft-utils snapshots -->
         <repository>
             <id>sonatype-ossrh</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
         <!-- item-nbt-api -->
         <repository>
-            <id>codemc-repo</id>
+            <id>codemc</id>
             <url>https://repo.codemc.org/repository/maven-public/</url>
         </repository>
     </repositories>
@@ -161,6 +160,11 @@
     <dependencyManagement>
         <dependencies>
             <!-- Own dependencies -->
+            <dependency>
+                <groupId>ru.divinecraft</groupId>
+                <artifactId>zaraza-common-api</artifactId>
+                <version>${version.zaraza}</version>
+            </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>custom-stuff-api</artifactId>
@@ -176,25 +180,6 @@
             </dependency>
 
             <!-- Libraries -->
-            <dependency>
-                <groupId>ru.progrm-jarvis</groupId>
-                <artifactId>java-commons</artifactId>
-                <version>1.0-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>ru.progrm-jarvis.minecraft</groupId>
-                <artifactId>minecraft-commons</artifactId>
-                <version>${version.minecraft-utils}</version>
-            </dependency>
-            <!--
-            Note: While this is not in use by the API itself, it still is required to be present at runtime
-            as a lot of naive logic may be based on it.
-            -->
-            <dependency>
-                <groupId>ru.progrm-jarvis.minecraft</groupId>
-                <artifactId>fake-entity-lib</artifactId>
-                <version>${version.minecraft-utils}</version>
-            </dependency>
             <dependency>
                 <groupId>com.flowpowered</groupId>
                 <artifactId>flow-nbt</artifactId>


### PR DESCRIPTION
# Description

This:
- enables usage of `zaraza-commons-api` which provides basic dependencies.
- migrates to Java 11