### PR TITLE
feat: deprecate `CustomBlockManager#createBlock(..)`

### DIFF
--- a/custom-stuff-api/src/main/java/ru/divinecraft/customstuff/api/block/manager/CustomBlockManager.java
+++ b/custom-stuff-api/src/main/java/ru/divinecraft/customstuff/api/block/manager/CustomBlockManager.java
@@ -30,6 +30,7 @@ public interface CustomBlockManager {
 
     @Nullable CustomBlock getBlock(@NotNull Location location);
 
+    @Deprecated // this does not register the block in a chunk and is only used by chunk readers implementations
     @NotNull CustomBlock createBlock(@NotNull Location location,
                                      @NotNull NamespacedKey type,
                                      @Nullable BlockFace direction,


### PR DESCRIPTION
# Description

This deprecated `CustomBlockManager#createBlock(..)` which (in current form) should not be part of the API.